### PR TITLE
Load text translation on init action for wp >=6.7.0

### DIFF
--- a/sa11y-wp.php
+++ b/sa11y-wp.php
@@ -137,7 +137,11 @@ class Sa11y_WP
     add_action('plugins_loaded', array(&$this, 'constants'), 1);
 
     // Internationalize the text strings used.
-    add_action('init', array(&$this, 'i18n'), 2);
+    if (version_compare(wp_get_wp_version(), '6.7.0', '>=')) {
+        add_action('init', array(&$this, 'i18n'), 2);
+    } else {
+        add_action('plugins_loaded', array(&$this, 'i18n'), 2);
+    }
 
     // Load the functions files.
     add_action('plugins_loaded', array(&$this, 'includes'), 3);

--- a/sa11y-wp.php
+++ b/sa11y-wp.php
@@ -137,7 +137,7 @@ class Sa11y_WP
     add_action('plugins_loaded', array(&$this, 'constants'), 1);
 
     // Internationalize the text strings used.
-    add_action('plugins_loaded', array(&$this, 'i18n'), 2);
+    add_action('init', array(&$this, 'i18n'), 2);
 
     // Load the functions files.
     add_action('plugins_loaded', array(&$this, 'includes'), 3);


### PR DESCRIPTION
Fixes the notice message:

Translation loading for the plugin domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.)